### PR TITLE
Improve DB to cache and sort cascading ids

### DIFF
--- a/spinedb_api/db_mapping_add_mixin.py
+++ b/spinedb_api/db_mapping_add_mixin.py
@@ -141,7 +141,7 @@ class DatabaseMappingAddMixin:
         """
         if readd:
             self._readd_items(tablename, *items)
-            return
+            return items if return_items else {x["id"] for x in items}, []
         if check:
             checked_items, intgr_error_log = self.check_items(
                 tablename, *items, for_update=False, strict=strict, cache=cache

--- a/spinedb_api/db_mapping_remove_mixin.py
+++ b/spinedb_api/db_mapping_remove_mixin.py
@@ -90,7 +90,16 @@ class DatabaseMappingRemoveMixin:
         self._merge(
             ids, self._parameter_value_metadata_cascading_ids(kwargs.get("parameter_value_metadata", set()), cache)
         )
-        return {key: value for key, value in ids.items() if value}
+        sorted_ids = {}
+        tablenames = list(ids)
+        while tablenames:
+            tablename = tablenames.pop(0)
+            ancestors = self.ancestor_tablenames.get(tablename)
+            if ancestors is None or all(x in sorted_ids for x in ancestors):
+                sorted_ids[tablename] = ids.pop(tablename)
+            else:
+                tablenames.append(tablename)
+        return sorted_ids
 
     @staticmethod
     def _merge(left, right):

--- a/spinedb_api/db_mapping_update_mixin.py
+++ b/spinedb_api/db_mapping_update_mixin.py
@@ -347,7 +347,13 @@ class DatabaseMappingUpdateMixin:
                 [int(x) for x in current_alternative_id_list.split(",")] if current_alternative_id_list else []
             )
             for k, alternative_id in enumerate(alternative_id_list):
-                item_to_add = {"scenario_id": scenario_id, "alternative_id": alternative_id, "rank": k + 1}
+                item_to_add = {
+                    "scenario_id": scenario_id,
+                    "alternative_id": alternative_id,
+                    "rank": k + 1,
+                    "before_alternative_id": alternative_id_list[k],
+                    "before_rank": k,
+                }
                 items_to_add.append(item_to_add)
             for alternative_id in current_alternative_id_list:
                 ids_to_remove.add(scenario_alternative_ids[scenario_id, alternative_id])


### PR DESCRIPTION
Conversion from DB item to cache item needed some missing keys. Also, we sort items in cascading_ids by precedence.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
