### PR TITLE
Fix importing values to existing value list

### DIFF
--- a/spinedb_api/import_functions.py
+++ b/spinedb_api/import_functions.py
@@ -1650,7 +1650,7 @@ def _get_list_values_for_import(db_map, data, make_cache, unparse_value):
         elif value_index_list is None:
             index = 0
         else:
-            index = int(max(value_index_list.split(","))) + 1
+            index = max(map(int, value_index_list.split(","))) + 1
         item = {"parameter_value_list_id": list_id, "value": val, "type": type_, "index": index}
         try:
             check_list_value(item, list_names_by_id, list_value_ids_by_index, list_value_ids_by_value)

--- a/spinedb_api/spine_db_server.py
+++ b/spinedb_api/spine_db_server.py
@@ -231,10 +231,7 @@ class _DBWorker:
     def _do_work(self):
         try:
             self._db_map = DatabaseMapping(
-                self._db_url,
-                upgrade=self._upgrade,
-                memory=self._memory,
-                create=self._create,
+                self._db_url, upgrade=self._upgrade, memory=self._memory, create=self._create
             )
             self._out_queue.put(None)
         except Exception as error:  # pylint: disable=broad-except
@@ -405,11 +402,9 @@ class HandleDBMixin:
 
     def apply_filters(self, filters):
         configs = [
-            {
-                "scenario": scenario_filter_config,
-                "tool": tool_filter_config,
-                "alternatives": alternative_filter_config,
-            }[key](value)
+            {"scenario": scenario_filter_config, "tool": tool_filter_config, "alternatives": alternative_filter_config}[
+                key
+            ](value)
             for key, value in filters.items()
         ]
         return _db_manager.apply_filters(self.server_address, configs)
@@ -440,10 +435,7 @@ class HandleDBMixin:
         # NOTE: Clients should always send requests "get_api_version" and "get_db_url" in a format that is compatible
         # with the legacy server -- to (based on the format of the answer) determine that it needs to be updated.
         # That's why we don't expand the extras so far.
-        response = {
-            "get_api_version": spinedb_api_version,
-            "get_db_url": self.get_db_url(),
-        }.get(request)
+        response = {"get_api_version": spinedb_api_version, "get_db_url": self.get_db_url()}.get(request)
         if response is not None:
             return response
         try:

--- a/tests/test_import_functions.py
+++ b/tests/test_import_functions.py
@@ -933,6 +933,25 @@ class TestImportParameterValueList(unittest.TestCase):
         self.assertEqual(from_database(list_values[0].value, list_values[0].type), 23.0)
         self.assertEqual(list_values[0].index, 0)
 
+    def test_import_twelfth_value(self):
+        n_values = 11
+        initial_list = tuple(("list_1", 1.1 * i) for i in range(1, n_values + 1))
+        count, errors = import_parameter_value_lists(self._db_map, initial_list)
+        self.assertEqual(errors, [])
+        self.assertEqual(count, n_values + 1)
+        count, errors = import_parameter_value_lists(self._db_map, (("list_1", 23.0),))
+        self.assertEqual(errors, [])
+        self.assertEqual(count, 1)
+        value_lists = self._db_map.query(self._db_map.parameter_value_list_sq).all()
+        self.assertEqual(len(value_lists), 1)
+        self.assertEqual(value_lists[0].name, "list_1")
+        list_values = self._db_map.query(self._db_map.list_value_sq).all()
+        self.assertEqual(len(list_values), n_values + 1)
+        expected = {i: 1.1 * (i + 1) for i in range(n_values)}
+        expected[len(expected)] = 23.0
+        for row in list_values:
+            self.assertEqual(from_database(row.value, row.type), expected[row.index])
+
 
 class TestImportAlternative(unittest.TestCase):
     def test_single_alternative(self):


### PR DESCRIPTION
Fixed an algorithm in `import_functions` that was used to find the next usable index in value lists. The algorithm was broken if there were more than 10 values in the list.

Fixes #188
## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
