### PR TITLE
Fix problem when importing values from SpineDBManager

### DIFF
--- a/spinedb_api/import_functions.py
+++ b/spinedb_api/import_functions.py
@@ -1647,7 +1647,7 @@ def _get_list_values_for_import(db_map, data, make_cache, unparse_value):
         max_index = max_indexes.get(list_id)
         if max_index is not None:
             index = max_index + 1
-        elif value_index_list is None:
+        elif not value_index_list:
             index = 0
         else:
             index = max(map(int, value_index_list.split(","))) + 1


### PR DESCRIPTION
Manager's cache is slightly different than what we're used to in spinedb_api. We should still accept it.

Fixes Spine-project/Spine-Toolbox#1851

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
