### PR TITLE
Replace sort key lambdas by attribute and item getters where applicable

### DIFF
--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -21,6 +21,7 @@ import os
 import logging
 import time
 from collections import Counter
+from operator import itemgetter
 from types import MethodType
 from sqlalchemy import create_engine, case, MetaData, Table, Column, false, and_, func, inspect, cast, Integer, or_
 from sqlalchemy.sql.expression import label, Alias
@@ -2168,7 +2169,7 @@ class DatabaseMappingBase:
         item["active"] = item.get("active", False)
         sorted_scen_alts = sorted(
             (x for x in cache.get("scenario_alternative", {}).values() if x["scenario_id"] == item["id"]),
-            key=lambda x: x["rank"],
+            key=itemgetter("rank"),
         )
         item["alternative_id_list"] = ",".join(str(x.get("alternative_id")) for x in sorted_scen_alts)
         item["alternative_name_list"] = ",".join(x.get("alternative_name") for x in sorted_scen_alts)
@@ -2216,7 +2217,7 @@ class DatabaseMappingBase:
         item = item.copy()
         sorted_list_values = sorted(
             (x for x in cache.get("list_value", {}).values() if x["parameter_value_list_id"] == item["id"]),
-            key=lambda x: x["index"],
+            key=itemgetter("index"),
         )
         item["value_index_list"] = ",".join(str(x["index"]) for x in sorted_list_values)
         item["value_id_list"] = ",".join(str(x["id"]) for x in sorted_list_values)

--- a/spinedb_api/export_functions.py
+++ b/spinedb_api/export_functions.py
@@ -15,6 +15,7 @@ Functions for exporting data from a Spine database using entity names as referen
 :author: M. Marin (KTH)
 :date:   1.4.2020
 """
+from operator import itemgetter
 
 from sqlalchemy.util import KeyedTuple
 from .parameter_value import from_database
@@ -161,7 +162,7 @@ def export_parameter_value_lists(db_map, ids=Asterisk, make_cache=None, parse_va
 
     return sorted(
         ((x.name, parse_value(x.value, x.type)) for x in _get_items(db_map, "parameter_value_list", ids, make_cache)),
-        key=lambda x: x[0],
+        key=itemgetter(0),
     )
 
 
@@ -286,7 +287,7 @@ def export_scenario_alternatives(db_map, ids=Asterisk, make_cache=None):
             (x.scenario_name, x.alternative_name, x.before_alternative_name)
             for x in _get_items(db_map, "scenario_alternative", ids, make_cache)
         ),
-        key=lambda x: x[0],
+        key=itemgetter(0),
     )
 
 

--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -19,6 +19,7 @@ General helper functions and classes.
 import os
 import json
 import warnings
+from operator import itemgetter
 from urllib.parse import urlparse, urlunparse
 from sqlalchemy import (
     Boolean,
@@ -279,7 +280,7 @@ def compare_schemas(left_engine, right_engine):
 def schema_dict(insp):
     return {
         table_name: {
-            "columns": sorted(insp.get_columns(table_name), key=lambda x: x["name"]),
+            "columns": sorted(insp.get_columns(table_name), key=itemgetter("name")),
             "pk_constraint": insp.get_pk_constraint(table_name),
             "foreign_keys": sorted(insp.get_foreign_keys(table_name), key=lambda x: x["name"] or ""),
             "check_constraints": insp.get_check_constraints(table_name),


### PR DESCRIPTION
No functional changes intended. The attribute and item getters provide small performance boost over lambdas.

Re Spine-project/Spine-Toolbox#1854


## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
