### PR TITLE
Raise errors in opening DB maps from server

### DIFF
--- a/spinedb_api/spine_db_server.py
+++ b/spinedb_api/spine_db_server.py
@@ -133,7 +133,9 @@ class _DBServerManager:
         server_thread = threading.Thread(target=server.serve_forever)
         server_thread.daemon = True
         server_thread.start()
-        SpineDBClient(server.server_address).open_db_map(db_url, upgrade, memory)
+        error = SpineDBClient(server.server_address).open_db_map(db_url, upgrade, memory).get("error")
+        if error:
+            raise RuntimeError(error)
         return server.server_address
 
     def _shutdown_server(self, server_address):
@@ -500,7 +502,9 @@ class HandleDBMixin:
 class DBHandler(HandleDBMixin):
     def __init__(self, db_url, upgrade=False, memory=False):
         self.server_address = uuid.uuid4().hex
-        _db_manager.open_db_map(self.server_address, db_url, upgrade, memory)
+        error = _db_manager.open_db_map(self.server_address, db_url, upgrade, memory).get("error")
+        if error:
+            raise RuntimeError(error)
         atexit.register(self.close)
 
     def close(self):


### PR DESCRIPTION
Otherwise we could get something like "invalid request get_db_url" which doesn't say at all what the actual error is.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
