### PR TITLE
Fix Traceback in get_parameter_value_item()

### DIFF
--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -434,7 +434,12 @@ class ParameterItemBase(ParsedValueBase):
         if list_name is None:
             self["list_value_id"] = None
             return
-        type_ = super().__getitem__(self._type_key)
+        try:
+            type_ = super().__getitem__(self._type_key)
+        except KeyError:
+            if isinstance(self, ParameterValueItem):
+                return f"parameter value {self['parameter_definition_name']} for class {self['entity_class_name']}, entity {self['entity_byname']}, alternative {self['alternative_name']} has no list value"
+            return f"parameter {self['name']} for class {self['entity_class_name']} has no list value"
         if type_ == "list_value_ref":
             return
         value = super().__getitem__(self._value_key)


### PR DESCRIPTION
This PR fixes `DatabaseMapping.get_parameter_value_item()` which would Traceback when the parameter definition used a value list but the parameter value did not exists, e.g. when it is not defined in a specific alternative.

Fixes #401

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
