### PR TITLE
Fix convenience methods for metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ``DatabaseMapping.add_metadata()``, ``DatabaseMapping.add_entity_metadata()``, ``DatabaseMapping.add_parameter_value_metadata()``
+  as well as the corresponding ``remove_*``, ``update_*`` and ``add_or_update_*`` methods now work as the other "singular"
+  methods like ``DatabaseMapping.add_entity()``.
+  Previously, the methods would work on multiple items at once like ``DatabaseMapping.add_entities()``.
+  The new "plural" versions have ``_items`` at the end of the method name:
+  ``DatabaseMapping.add_metadata_items()``, ``DatabaseMapping.update_metadata_items()`` etc.
+
 ### Fixed
 
 ### Security

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -1266,9 +1266,9 @@ def _pluralize(item_type: str) -> str:
     plural = {
         "entity": "entities",
         "entity_class": "entity_classes",
-        "entity_metadata": "entity_metadata",
-        "metadata": "metadata",
-        "parameter_value_metadata": "parameter_value_metadata",
+        "entity_metadata": "entity_metadata_items",
+        "metadata": "metadata_items",
+        "parameter_value_metadata": "parameter_value_metadata_items",
         "superclass_subclass": "superclass_subclasses",
     }.get(item_type)
     if plural:

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -3131,6 +3131,20 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 values = db_map.find_parameter_values()
                 self.assertEqual(values, [])
 
+    def test_add_metadata(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_metadata(name="Title", value="Catalogue of things that should be")
+            metadata_record = db_map.metadata(name="Title", value="Catalogue of things that should be")
+            self.assertEqual(metadata_record["name"], "Title")
+            self.assertEqual(metadata_record["value"], "Catalogue of things that should be")
+
+    def test_add_metadata_items(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_metadata_items([{"name": "Title", "value": "Catalogue of things that should be"}])
+            metadata_record = db_map.metadata(name="Title", value="Catalogue of things that should be")
+            self.assertEqual(metadata_record["name"], "Title")
+            self.assertEqual(metadata_record["value"], "Catalogue of things that should be")
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
The "pluralized" versions of the methods cannot have same names as the "singular" versions or they will shadow each other. "Plural" metadata is now called `metadata_items`.

No associate issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
