### PR TITLE
Turn off field type sniffing in DatapackageReader

### DIFF
--- a/spinedb_api/spine_io/importers/datapackage_reader.py
+++ b/spinedb_api/spine_io/importers/datapackage_reader.py
@@ -62,7 +62,7 @@ class DatapackageReader(Reader):
             **extras: ignored
         """
         if source:
-            self._datapackage = frictionless.Package(source)
+            self._datapackage = frictionless.Package(source, detector=frictionless.Detector(field_type="string"))
             self._filename = source
 
     def disconnect(self):

--- a/tests/spine_io/importers/test_datapackage_reader.py
+++ b/tests/spine_io/importers/test_datapackage_reader.py
@@ -78,7 +78,7 @@ class TestDatapackageReader(unittest.TestCase):
             reader = DatapackageReader(None)
             reader.connect_to_source(str(package_path))
             cell_data = reader.get_table_cell("test_data", 1, 2, {"has_header": False})
-            self.assertEqual(cell_data, 23)
+            self.assertEqual(cell_data, "23")
 
     def test_get_table_cell_with_header(self):
         data = [["header 1", "header 2", "header 3"], ["11", "12", "13"], ["21", "22", "23"]]
@@ -86,7 +86,7 @@ class TestDatapackageReader(unittest.TestCase):
             reader = DatapackageReader(None)
             reader.connect_to_source(str(package_path))
             cell_data = reader.get_table_cell("test_data", 1, 2, {"has_header": True})
-            self.assertEqual(cell_data, 23)
+            self.assertEqual(cell_data, "23")
 
     def test_get_table_cell_with_row_out_of_bound(self):
         data = [["11", "12", "13"], ["21", "22", "23"]]
@@ -120,7 +120,7 @@ class TestDatapackageReader(unittest.TestCase):
             reader.connect_to_source(str(package_path))
             data, header = reader.get_data("test_data", {})
             self.assertEqual(header, ["header 1", "header 2", "header 3"])
-            self.assertEqual(data, 1000 * [[21, 22, 23]])
+            self.assertEqual(data, 1000 * [["21", "22", "23"]])
 
 
 @contextmanager


### PR DESCRIPTION
This fixes a bug in DatapackageReader where columns with float values sometimes failed to load properly.

Fixes spine-tools/Spine-Toolbox#3154

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
