### PR TITLE
Fix incorrect relationship naming after purge

### DIFF
--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -387,9 +387,12 @@ class EntityItem(MappedItemBase):
             for k in ("entity_class_name", "superclass_name"):
                 if (class_name := self[k]) is not None:
                     try:
-                        entity_table.find_item_by_unique_key({"entity_class_name": class_name, "name": name})
+                        existing = entity_table.find_item_by_unique_key({"entity_class_name": class_name, "name": name})
                     except SpineDBAPIError:
                         names_found -= 1
+                    else:
+                        if not existing.is_valid():
+                            names_found -= 1
                 else:
                     names_found -= 1
             if names_found == 0:

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -3307,6 +3307,19 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             db_map.add_scenario_alternative(scenario_name="scenario 1", alternative_name="alt 1", rank=2)
             self.assertEqual(base_scenario_alternative["before_alternative_id"], another_alternative["id"])
 
+    def test_add_relationship_after_purge(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            db_map.add_entity(name="thing", entity_class_name="Object")
+            db_map.add_entity_class(dimension_name_list=["Object", "Object"])
+            relationship = db_map.add_entity(entity_byname=("thing", "thing"), entity_class_name="Object__Object")
+            self.assertEqual(relationship["name"], "thing__thing")
+            db_map.purge_items("entity")
+            db_map.commit_session("Add test data")
+            db_map.add_entity(name="thing", entity_class_name="Object")
+            relationship = db_map.add_entity(entity_byname=("thing", "thing"), entity_class_name="Object__Object")
+            self.assertEqual(relationship["name"], "thing__thing")
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
Relationships that overwrite removed ones now get named correctly without extra `_1` prefix.

Fixes #556

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
