### PR TITLE
Code refactoring: Simplify scenario filter

### DIFF
--- a/spinedb_api/filters/query_utils.py
+++ b/spinedb_api/filters/query_utils.py
@@ -43,10 +43,7 @@ def filter_by_active_elements(db_map, query, ext_entity_sq):
         .subquery()
     )
     return (
-        query.outerjoin(
-            ext_entity_element_count_sq,
-            ext_entity_element_count_sq.c.entity_id == ext_entity_sq.c.id,
-        )
+        query.outerjoin(ext_entity_element_count_sq, ext_entity_element_count_sq.c.entity_id == ext_entity_sq.c.id)
         .outerjoin(
             ext_entity_class_dimension_count_sq,
             ext_entity_class_dimension_count_sq.c.entity_class_id == ext_entity_sq.c.class_id,


### PR DESCRIPTION
No issue related, no functionality added nor changed. I noticed we were filtering the result of ext_entity_sq() by the same criteria in multiple places on the caller side. For this reason it seemed better to just do the filtering already in ext_entity_sq().
The code becomes a little bit easier to follow this way.


## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
