### PR TITLE
Fix add items from DB and refresh

### DIFF
--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -195,12 +195,18 @@ class DatabaseMappingBase:
     def refresh_session(self):
         """Clears fetch progress, so the DB is queried again, and committed, unchanged items."""
         changed_statuses = {Status.to_add, Status.to_update, Status.to_remove}
+        to_remove = []
         for item_type in self.item_types():
             mapped_table = self._mapped_tables[item_type]
             for item in list(mapped_table.values()):
                 if item.status not in changed_statuses:
-                    mapped_table.remove_unique(item)
-                    del mapped_table[dict.__getitem__(item, "id")]
+                    to_remove.append((mapped_table, item))
+        # First remove unique keys, then ids, otherwise the unique keys are not fully removed
+        # due to missing references
+        for mapped_table, item in to_remove:
+            mapped_table.remove_unique(item)
+        for mapped_table, item in to_remove:
+            del mapped_table[dict.__getitem__(item, "id")]
         self._commit_count = None
         self._fetched.clear()
 
@@ -354,7 +360,9 @@ class MappedTable(dict):
                 return self._unique_key_value_to_item(key, value, fetch=fetch)
             except SpineDBAPIError:
                 continue
-        raise SpineDBAPIError(f"no {self.item_type} matching {item}")
+        raise SpineDBAPIError(
+            f"no {self.item_type} matching {item if not isinstance(item, MappedItemBase) else 'given item'}"
+        )
 
     def find_item_by_unique_key(self, item: dict, fetch: bool = True) -> MappedItemBase:
         try:
@@ -434,7 +442,7 @@ class MappedTable(dict):
             except ValueError:
                 pass
 
-    def _make_and_add_item(
+    def _make_item(
         self, item: Union[dict, MappedItemBase], ignore_polishing_errors: bool, check_invalid_refs: bool = False
     ) -> MappedItemBase:
         if not isinstance(item, MappedItemBase):
@@ -446,43 +454,46 @@ class MappedTable(dict):
                     raise error
             if check_invalid_refs and item.first_invalid_key() is not None:
                 return None
+        return item
+
+    def _and_add_item(self, item):
         db_id = item.pop("id", None) if item.has_valid_id else None
         item["id"] = new_id = TempId.new_unique(self.item_type, self._temp_id_lookup)
         if db_id is not None:
             new_id.resolve(db_id)
         self[new_id] = item
-        return item
 
     def add_item_from_db(self, item: dict, is_db_clean: bool) -> tuple[MappedItemBase, bool]:
         """Adds an item fetched from the DB."""
+        new_item = self._make_item(item, ignore_polishing_errors=True, check_invalid_refs=True)
+        if new_item is None:
+            # Item has a broken reference in the DB, nothing to do here
+            return None, None
         try:
-            mapped_item = self._find_fully_qualified_item_by_unique_key(item, fetch=False)
+            existing_item = self._find_fully_qualified_item_by_unique_key(new_item, fetch=False)
         except SpineDBAPIError:
-            mapped_item = self.get(item["id"])
-            if mapped_item:
-                if is_db_clean or self._same_item(mapped_item.db_equivalent(), item):
-                    return mapped_item, False
-                mapped_item.handle_id_steal()
-            mapped_item = self._make_and_add_item(item, ignore_polishing_errors=True, check_invalid_refs=True)
-            if mapped_item is None:
-                # Item has a broken reference in the DB, nothing to do here
-                return None, None
+            same_id_item = self.get(item["id"])
+            if same_id_item:
+                if is_db_clean or self._same_item(same_id_item.db_equivalent(), item):
+                    return same_id_item, False
+                same_id_item.handle_id_steal()
+            self._and_add_item(new_item)
             if self.purged:
                 # Lazy purge: instead of fetching all at purge time, we purge stuff as it comes.
-                mapped_item.cascade_remove()
-            return mapped_item, True
-        if is_db_clean or self._same_item(mapped_item, item):
-            mapped_item.force_id(item["id"])
-            if mapped_item.status == Status.to_add and (
-                mapped_item.replaced_item_waiting_for_removal is None
-                or mapped_item.replaced_item_waiting_for_removal["id"].db_id != item["id"]
+                new_item.cascade_remove()
+            return new_item, True
+        if is_db_clean or self._same_item(existing_item, item):
+            existing_item.force_id(item["id"])
+            if existing_item.status == Status.to_add and (
+                existing_item.replaced_item_waiting_for_removal is None
+                or existing_item.replaced_item_waiting_for_removal["id"].db_id != item["id"]
             ):
-                # We could test if the non-unique fields of mapped_item and db item are equal
+                # We could test if the non-unique fields of existing_item and db item are equal
                 # and set status to Status.committed
                 # but that is potentially complex operation (for e.g. large parameter values)
-                # so we take a shortcut here and assume that mapped_item always contains modified data.
-                mapped_item.status = Status.to_update
-            return mapped_item, False
+                # so we take a shortcut here and assume that existing_item always contains modified data.
+                existing_item.status = Status.to_update
+        return existing_item, False
 
     def _same_item(self, mapped_item: MappedItemBase, db_item: dict) -> bool:
         """Whether the two given items have the same unique keys.
@@ -524,7 +535,8 @@ class MappedTable(dict):
             raise SpineDBAPIError("\n".join(errors))
 
     def add_item(self, item: dict) -> MappedItemBase:
-        item = self._make_and_add_item(item, ignore_polishing_errors=False)
+        item = self._make_item(item, ignore_polishing_errors=False)
+        self._and_add_item(item)
         self.add_unique(item)
         item.become_referrer()
         item.status = Status.to_add

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -5866,6 +5866,21 @@ class TestDatabaseMappingConcurrent(AssertSuccessTestCase):
                 self.assertCountEqual(entity_class_names, ["cat", "dog"])
             db_map.engine.dispose()
 
+    def test_uncommitted_mapped_items_are_updated_by_externally_committed_items(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "database.sqlite")
+            with DatabaseMapping(url, create=True) as db_map1:
+                db_map1.add_entity_class(name="widget")
+                db_map1.add_entity(entity_class_name="widget", name="gadget")
+                with DatabaseMapping(url) as db_map2:
+                    # Add the same entity
+                    db_map2.add_entity_class(name="widget")
+                    db_map2.add_entity(entity_class_name="widget", name="gadget")
+                    db_map2.commit_session("No comment")
+                db_map2.engine.dispose()
+                db_map1.commit_session("No comment")
+            db_map1.engine.dispose()
+
     def test_uncommitted_mapped_items_take_id_from_externally_committed_items(self):
         with TemporaryDirectory() as temp_dir:
             url = "sqlite:///" + os.path.join(temp_dir, "database.sqlite")


### PR DESCRIPTION
Fetching an item that was equivalent to one from the memory mapping created a duplicate instead of merging. Then, committing resulted in unique constraint violations.
Seems like we carried this one from long ago.

Also, refreshing didn't remove all the unique key values due to the order in which we did things.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
