### PR TITLE
Only check broken references after all items are fetched

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -1063,12 +1063,15 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
                 new_items.append(item)
             else:
                 item.handle_refetch()
-            items.append(item)
+                items.append(item)
         # Once all items are added, add the unique key values
         # Otherwise items that refer to other items that come later in the query will be seen as corrupted
         for item in new_items:
+            if not item.become_referrer():
+                mapped_table.remove_item(item)
+                continue
             mapped_table.add_unique(item)
-            item.become_referrer()
+            items.append(item)
         return items
 
     def fetch_more(self, item_type, offset=0, limit=None, **kwargs):


### PR DESCRIPTION
Otherwise there would be false positives for self-referencing tables (an item migth reference another item that comes later in the query and thus we need to wait for the latter to show up before we can validate the former).


## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
