### PR TITLE
Fix spurious failure in GAMS version version

### DIFF
--- a/spinedb_api/spine_io/gdx_utils.py
+++ b/spinedb_api/spine_io/gdx_utils.py
@@ -16,6 +16,7 @@ import os
 import re
 import subprocess
 import sys
+from tempfile import TemporaryDirectory
 from typing import Optional
 
 if sys.platform == "win32":
@@ -66,7 +67,13 @@ def find_gams_directory() -> Optional[str]:
 
 def gams_supports_new_api(gams_path: str) -> bool:
     gams_exec = os.path.join(gams_path, "gams")
-    completed = subprocess.run([gams_exec, "?"], capture_output=True, text=True)
+    with TemporaryDirectory() as work_dir:
+        # We use a temporary directory here to ensure we run the command in a writable place.
+        # GAMS creates some temporary folders when executed.
+        # If this fails e.g. because the user has no write access to the current work directory,
+        # the command fails as well.
+        # The current work directory may be read-only e.g. when Toolbox was started from a read-only directory.
+        completed = subprocess.run([gams_exec, "?"], cwd=work_dir, capture_output=True, text=True)
     if completed.returncode != 0 or completed.stderr:
         return False
     version_re = re.compile(r"^\*\*\* GAMS Release +: (?P<major>\d+)")

--- a/tests/spine_io/test_gdx_utils.py
+++ b/tests/spine_io/test_gdx_utils.py
@@ -141,7 +141,42 @@ class TestGamsSupportsNewApi:
 *** Note: For solvers, other expiration dates may apply.
 *** Status: Normal completion
 --- Job ? Stop 08/07/25 11:58:53 elapsed 0:00:00.016"""
-        for output, expected in [(output_24, False), (output_41, False), (output_42, True), (output_47, True)]:
+        output_48 = r"""--- Job ? Start 09/16/25 11:10:09 48.3.0 71b5641f WEX-WEI x86 64bit/MS Windows
+***
+*** GAMS Base Module 48.3.0 71b5641f Nov 12, 2024          WEI x86 64bit/MS Window
+***
+*** GAMS Development Corporation
+*** 2751 Prosperity Ave, Suite 210
+*** Fairfax, VA 22031, USA
+*** +1 202-342-0180, +1 202-342-0181 fax
+*** support@gams.com, www.gams.com
+***
+*** GAMS Release     : 48.3.0 71b5641f WEX-WEI x86 64bit/MS Windows
+*** Release Date     : Nov 12, 2024
+*** To use this release, you must have a valid license file for
+*** this platform with maintenance expiration date later than
+*** Oct 14, 2024
+*** System Directory : C:\GAMS\48\
+***
+*** License          : C:\xxx\hassle\22222222222222222222222222222222
+*** Large MUD - 20 User License                    S241010|0002CO-GEN
+*** VTT Technical Research Centre of Finland Ltd, CARO
+*** DC16012 01CL
+*** License Admin: N. N., n.n@example.com
+***
+*** Licensed platform                             : Generic platforms
+*** The installed license is valid.
+*** Maintenance expiration date (GAMS base module): Feb 02, 2026
+*** Note: For solvers, other expiration dates may apply.
+*** Status: Normal completion
+--- Job ? Stop 09/16/25 11:10:09 elapsed 0:00:00.016"""
+        for output, expected in [
+            (output_24, False),
+            (output_41, False),
+            (output_42, True),
+            (output_47, True),
+            (output_48, True),
+        ]:
             completed_process = mock.MagicMock()
             completed_process.returncode = 0
             completed_process.stderr = ""
@@ -149,6 +184,8 @@ class TestGamsSupportsNewApi:
             with mock.patch("spinedb_api.spine_io.gdx_utils.subprocess.run") as mock_run:
                 mock_run.return_value = completed_process
                 assert gams_supports_new_api(r"C:\GAMS\xxx") == expected
-                mock_run.assert_called_once_with(
-                    [os.path.join(r"C:\GAMS\xxx", "gams"), "?"], capture_output=True, text=True
-                )
+                assert mock_run.call_args[0] == ([os.path.join(r"C:\GAMS\xxx", "gams"), "?"],)
+                assert len(mock_run.call_args[1]) == 3
+                assert "cwd" in mock_run.call_args[1]
+                assert mock_run.call_args[1]["capture_output"]
+                assert mock_run.call_args[1]["text"]


### PR DESCRIPTION
This fixes an issue where GAMS version check failed if Toolbox was started from a read-only directory.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
