### PR TITLE
Add "parsed_value_list" key to ParameterValueListItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `parameter_value_list` items now have a field `parsed_value_list` which contains the list of parsed list values,
+  sorted by index. For example, if a value list `answers` contains values `yes` and `no`, then 
+
+```python
+answers = db_map.parameter_value_list(name="answers")
+assert answers["parsed_value_list"] == ["yes", "no"]  
+```
+
 ### Changed
 
 ### Deprecated

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -1104,6 +1104,16 @@ class ParameterValueListItem(MappedItemBase):
     unique_keys = (("name",),)
     required_key_combinations = (("name",),)
 
+    def __getitem__(self, key):
+        if key == "parsed_value_list":
+            list_value_table = self.db_map.mapped_table("list_value")
+            list_value_items = self.db_map.find(
+                list_value_table, parameter_value_list_name=dict.__getitem__(self, "name")
+            )
+            list_value_items.sort(key=itemgetter("index"))
+            return [item["parsed_value"] for item in list_value_items]
+        return super().__getitem__(key)
+
 
 class ListValueItem(ParsedValueBase):
     item_type = "list_value"

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -3345,6 +3345,13 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 )
             db_map.close()
 
+    def test_parsed_value_list(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            value_list_item = db_map.add_parameter_value_list(name="Enumeration")
+            db_map.add_list_value(parameter_value_list_name="Enumeration", parsed_value=2.3, index=2)
+            db_map.add_list_value(parameter_value_list_name="Enumeration", parsed_value=3.2, index=1)
+            self.assertEqual(value_list_item["parsed_value_list"], [3.2, 2.3])
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
The key returns a list of parsed list values, sorted by index, i.e.

```python
methods = db_map.parameter_value_list(name="methods")
assert methods["parsed_value_list"] == ["method_a", "method_b", "method_c"]
```

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
