### PR TITLE
Relax checks on entity location

### DIFF
--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -411,23 +411,15 @@ class EntityItem(MappedItemBase):
     def _pop_location_data(item: dict) -> dict[str, str]:
         location = {}
         if "lat" in item:
-            if "lon" not in item:
-                raise SpineDBAPIError("cannot set latitude without longitude")
             location["lat"] = item.pop("lat")
+        if "lon" in item:
             location["lon"] = item.pop("lon")
-            with suppress(KeyError):
-                location["alt"] = item.pop("alt")
-        elif "lon" in item:
-            raise SpineDBAPIError("cannot set longitude without latitude")
-        elif "alt" in item:
-            raise SpineDBAPIError("cannot set altitude without latitude and longitude")
+        if "alt" in item:
+            location["alt"] = item.pop("alt")
         if "shape_name" in item:
-            if "shape_blob" not in item:
-                raise SpineDBAPIError("cannot set shape_name without shape_blob")
             location["shape_name"] = item.pop("shape_name")
+        if "shape_blob" in item:
             location["shape_blob"] = item.pop("shape_blob")
-        elif "shape_blob" in item:
-            raise SpineDBAPIError("cannot set shape_blob without shape_name")
         return location
 
     def added_to_mapped_table(self) -> None:
@@ -1450,24 +1442,6 @@ class EntityLocationItem(MappedItemBase):
     _internal_fields = {
         "entity_id": (("entity_class_name", "entity_byname"), "id"),
     }
-
-    def check_mutability(self):
-        latitude = dict.__getitem__(self, "lat")
-        longitude = dict.__getitem__(self, "lon")
-        if latitude is not None:
-            if longitude is None:
-                raise SpineDBAPIError("latitude cannot be set if longitude is None")
-        elif longitude is not None:
-            raise SpineDBAPIError("longitude cannot be set if latitude is None")
-        if dict.__getitem__(self, "alt") is not None and latitude is None and longitude is None:
-            raise SpineDBAPIError("altitude cannot be set if latitude and longitude are None")
-        name = dict.__getitem__(self, "shape_name")
-        blob = dict.__getitem__(self, "shape_blob")
-        if name is not None:
-            if blob is None:
-                raise SpineDBAPIError("shape_name cannot be set if shape_blob is None")
-        elif blob is not None:
-            raise SpineDBAPIError("shape_blob cannot be set if shape_name is None")
 
 
 ITEM_CLASSES = tuple(

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -2566,20 +2566,6 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             self.assertEqual(entity["shape_name"], "island")
             self.assertEqual(entity["shape_blob"], "{}")
 
-    def test_add_entity_with_incomplete_location_data_raises(self):
-        with DatabaseMapping("sqlite://", create=True) as db_map:
-            db_map.add_entity_class(name="Object")
-            with self.assertRaisesRegex(SpineDBAPIError, "cannot set latitude without longitude"):
-                db_map.add_entity(entity_class_name="Object", name="gadget", lat=2.3)
-            with self.assertRaisesRegex(SpineDBAPIError, "cannot set longitude without latitude"):
-                db_map.add_entity(entity_class_name="Object", name="gadget", lon=3.2)
-            with self.assertRaisesRegex(SpineDBAPIError, "cannot set altitude without latitude and longitude"):
-                db_map.add_entity(entity_class_name="Object", name="gadget", alt=55.0)
-            with self.assertRaisesRegex(SpineDBAPIError, "cannot set shape_name without shape_blob"):
-                db_map.add_entity(entity_class_name="Object", name="gadget", shape_name="island")
-            with self.assertRaisesRegex(SpineDBAPIError, "cannot set shape_blob without shape_name"):
-                db_map.add_entity(entity_class_name="Object", name="gadget", shape_blob="{}}")
-
     def test_location_data_available_from_database(self):
         with TemporaryDirectory() as temp_dir:
             url = "sqlite:///" + os.path.join(temp_dir, "db.sqlite")
@@ -2871,21 +2857,6 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 self.assertEqual(entity["shape_blob"], '{"feature": {}}')
             db_map.close()
             gc.collect()
-
-    def test_updating_entitys_location_data_with_missing_data_raises_exception(self):
-        with DatabaseMapping("sqlite://", create=True) as db_map:
-            db_map.add_entity_class(name="Object")
-            entity = db_map.add_entity(entity_class_name="Object", name="soon_to_have_location")
-            with self.assertRaisesRegex(SpineDBAPIError, "latitude cannot be set if longitude is None"):
-                entity.update(lat=2.3)
-            with self.assertRaisesRegex(SpineDBAPIError, "longitude cannot be set if latitude is None"):
-                entity.update(lon=3.2)
-            with self.assertRaisesRegex(SpineDBAPIError, "altitude cannot be set if latitude and longitude are None"):
-                entity.update(alt=55.0)
-            with self.assertRaisesRegex(SpineDBAPIError, "shape_name cannot be set if shape_blob is None"):
-                entity.update(shape_name="monogon")
-            with self.assertRaisesRegex(SpineDBAPIError, "shape_blob cannot be set if shape_name is None"):
-                entity.update(shape_blob="{}}")
 
     def test_removing_entity_location_sets_entitys_location_id_to_none(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:


### PR DESCRIPTION
Previously, you couldn't set `lat` without `lon` or `alt` without `lat` and `lon`. `shape_name` and `shape_blob` had similarly strict checks which prevented entering the values in DB editor one-by-one.

Re spine-tools/Spine-Toolbox#3207

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
